### PR TITLE
Add info alert for no search results

### DIFF
--- a/distiller/audit_search/templates/audit_search/search.html
+++ b/distiller/audit_search/templates/audit_search/search.html
@@ -242,6 +242,12 @@
           </div>
         </div>
       </div>
+    {% else %}
+      <div class="usa-alert usa-alert--info" >
+        <div class="usa-alert__body">
+          <p class="usa-alert__text">No agency findings within time period searched.</p>
+        </div>
+      </div>
     {% endif %}
   </div>
 


### PR DESCRIPTION
Implements issue(s) #4

Changes proposed in this pull request:
- Add text provided in #4 when there are no results